### PR TITLE
[#6] 공유앨범 초대코드 스키마 구성

### DIFF
--- a/prisma/migrations/20230920151104_init/migration.sql
+++ b/prisma/migrations/20230920151104_init/migration.sql
@@ -35,7 +35,7 @@ CREATE TABLE `ShareAlbumMember` (
 -- CreateTable
 CREATE TABLE `ShareAlbumHistory` (
     `id` VARCHAR(191) NOT NULL,
-    `type` ENUM('CREATE_SHARE_ALBUM', 'UPDATE_SHARE_ALBUM', 'DELETE_SHARE_ALBUM', 'JOIN_SHARE_ALBUM', 'LEAVE_SHARE_ALBUM', 'INVITE_SHARE_ALBUM', 'REMOVE_SHARE_ALBUM') NOT NULL,
+    `type` ENUM('CREATE_SHARE_ALBUM', 'UPDATE_SHARE_ALBUM', 'DELETE_SHARE_ALBUM', 'INVITE_SHARE_ALBUM', 'JOIN_SHARE_ALBUM', 'LEAVE_SHARE_ALBUM') NOT NULL,
     `shareAlbumId` VARCHAR(191) NOT NULL,
     `contentId` VARCHAR(191) NULL,
     `userId` INTEGER NULL,
@@ -47,8 +47,25 @@ CREATE TABLE `ShareAlbumHistory` (
     PRIMARY KEY (`id`)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
+-- CreateTable
+CREATE TABLE `ShareAlbumInviteCode` (
+    `id` VARCHAR(191) NOT NULL,
+    `shareAlbumId` VARCHAR(191) NOT NULL,
+    `code` VARCHAR(191) NOT NULL,
+    `deletedAt` DATETIME(3) NULL,
+    `updatedAt` DATETIME(3) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `ShareAlbumInviteCode_id`(`id`),
+    INDEX `ShareAlbumInviteCode_code`(`code`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
 -- AddForeignKey
 ALTER TABLE `ShareAlbumMember` ADD CONSTRAINT `ShareAlbumMember_shareAlbumId_fkey` FOREIGN KEY (`shareAlbumId`) REFERENCES `ShareAlbum`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE `ShareAlbumHistory` ADD CONSTRAINT `ShareAlbumHistory_shareAlbumId_fkey` FOREIGN KEY (`shareAlbumId`) REFERENCES `ShareAlbum`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ShareAlbumInviteCode` ADD CONSTRAINT `ShareAlbumInviteCode_shareAlbumId_fkey` FOREIGN KEY (`shareAlbumId`) REFERENCES `ShareAlbum`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20230920151421_init/migration.sql
+++ b/prisma/migrations/20230920151421_init/migration.sql
@@ -56,6 +56,7 @@ CREATE TABLE `ShareAlbumInviteCode` (
     `updatedAt` DATETIME(3) NOT NULL,
     `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 
+    UNIQUE INDEX `ShareAlbumInviteCode_code_key`(`code`),
     INDEX `ShareAlbumInviteCode_id`(`id`),
     INDEX `ShareAlbumInviteCode_code`(`code`),
     PRIMARY KEY (`id`)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,21 +12,23 @@ datasource db {
 
 /// 공유앨범
 model ShareAlbum {
-  id                  String              @id @default(cuid())
-  name                String
-  bio                 String?
-  thumbnailIId        String?
-  smallThumbnailIUrl  String?
-  mediumThumbnailIUrl String?
-  largeThumbnailIUrl  String?
-  deletedAt           DateTime?
-  updatedAt           DateTime            @updatedAt
-  createdAt           DateTime            @default(now())
+  id                   String                 @id @default(cuid())
+  name                 String
+  bio                  String?
+  thumbnailIId         String?
+  smallThumbnailIUrl   String?
+  mediumThumbnailIUrl  String?
+  largeThumbnailIUrl   String?
+  deletedAt            DateTime?
+  updatedAt            DateTime               @updatedAt
+  createdAt            DateTime               @default(now())
   // Relation
   // ShareAlbum --< ShareAlbumMember
-  shareAlbumMember    ShareAlbumMember[]
+  shareAlbumMember     ShareAlbumMember[]
   // ShareAlbum --< ShareAlbumHistory
-  shareAlbumHistory   ShareAlbumHistory[]
+  shareAlbumHistory    ShareAlbumHistory[]
+  // ShareAlbum --< ShareAlbumInviteCode
+  shareAlbumInviteCode ShareAlbumInviteCode[]
 
   //Index
   @@index([id], name: "ShareAlbum_id")
@@ -80,11 +82,35 @@ model ShareAlbumHistory {
 
 /// 공유앨범 히스토리 타입
 enum ShareAlbumHistoryType {
+  // 공유앨범 히스토리
+  /// 공유앨범 생성
   CREATE_SHARE_ALBUM
+  /// 공유앨범 수정
   UPDATE_SHARE_ALBUM
+  /// 공유앨범 삭제
   DELETE_SHARE_ALBUM
-  JOIN_SHARE_ALBUM
-  LEAVE_SHARE_ALBUM
+  // 공유앨범 멤버 히스토리
+  /// 공유앨범 초대
   INVITE_SHARE_ALBUM
-  REMOVE_SHARE_ALBUM
+  /// 공유앨범 가입
+  JOIN_SHARE_ALBUM
+  /// 공유앨범 탈퇴
+  LEAVE_SHARE_ALBUM
+}
+
+/// 공유앨범 초대코드
+model ShareAlbumInviteCode {
+  id           String     @id @default(cuid())
+  shareAlbumId String
+  code         String
+  deletedAt    DateTime?
+  updatedAt    DateTime   @updatedAt
+  createdAt    DateTime   @default(now())
+  // Relation
+  // ShareAlbumInviteCode >-- ShareAlbum
+  shareAlbum   ShareAlbum @relation(fields: [shareAlbumId], references: [id])
+
+  // Index
+  @@index([id], name: "ShareAlbumInviteCode_id")
+  @@index([code], name: "ShareAlbumInviteCode_code")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,7 +102,7 @@ enum ShareAlbumHistoryType {
 model ShareAlbumInviteCode {
   id           String     @id @default(cuid())
   shareAlbumId String
-  code         String
+  code         String     @unique
   deletedAt    DateTime?
   updatedAt    DateTime   @updatedAt
   createdAt    DateTime   @default(now())


### PR DESCRIPTION
# 공유앨범 초대코드 정책
- 초대코드를 생성할 수 있다
- 초대 코드를 생성하면 회원은 초대코드를 통해 가입을 진행할 수 있다
- 초대 코드는 별도 유효기간, 유효 카운트는 없으나 추후 추가 가능성을 염두해야한다


resolve #6 