### PR TITLE
[#30] 배포를 위한 도커파일 작성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+*.md
+build
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Hydrogen  Node.js 18.x Bilder
+FROM node:hydrogen-alpine AS builder
+
+# 앱 디렉터리 생성
+WORKDIR /build
+
+# 앱 의존성 설치 use pnpm
+COPY ./ ./
+RUN npm install -g pnpm
+RUN pnpm install --frozen-lockfile
+
+# 앱 빌드
+RUN pnpm run build
+
+# Hydrogen  Node.js 18.x App
+FROM node:hydrogen-alpine AS app
+
+# NODE_ENV 환경변수 설정
+ARG NODE_ENV
+RUN echo $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
+
+# 앱 디렉터리 생성
+WORKDIR /app
+
+# 앱 의존성 설치 use pnpm
+COPY ["package.json", "pnpm-lock.yaml", "./"]
+RUN npm install -g pnpm
+RUN pnpm i --frozen-lockfile -P
+
+# 앱 소스 추가
+COPY --from=builder /build/dist ./dist
+COPY --from=builder /build/environments ./environments
+COPY --from=builder /build/prisma ./prisma
+RUN ls -al
+
+EXPOSE 8080
+RUN pnpm run prisma:generate
+ENTRYPOINT [ "node", "dist/main" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN pnpm i --frozen-lockfile -P
 COPY --from=builder /build/dist ./dist
 COPY --from=builder /build/environments ./environments
 COPY --from=builder /build/prisma ./prisma
-RUN ls -al
 
 EXPOSE 8080
 RUN pnpm run prisma:generate

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prisma:generate": "npx prisma generate",
     "prisma:push:local": "dotenv -e environments/.env.local -- npx prisma db push",
-    "prisma:migrate:local": "dotenv -e environments/.env.local -- npx prisma migrate dev"
+    "prisma:migrate:local": "dotenv -e environments/.env.local -- npx prisma migrate dev",
+    "prisma:deploy:prod": "dotenv -e environments/.env.production -- npx prisma migrate deploy"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",


### PR DESCRIPTION
배포에 필요한 도커파일을 작성 했습니다.
builder에서 빌드 후 빌드된 파일을 app으로 옮겨 이미지 사이즈를 줄이는 구조로 작성 했습니다.

파이프라인에서 별도로 추가 처리가 필요한 작업은 다음과 같습니다.
- openAPI JSON 빌드 후 SDK 레포에 커밋
- prisma deploy
- 환경변수 생성