### PR TITLE
fix: 피드 생성 시 콘텐츠 정보를 옵셔널로 변경

### DIFF
--- a/src/feed/command/create-feed/create-feed.command.ts
+++ b/src/feed/command/create-feed/create-feed.command.ts
@@ -11,7 +11,7 @@ export class CreateFeedCommand {
   description?: string;
 
   /** 피드 콘텐츠 */
-  contents: {
+  contents?: {
     /** 콘텐츠 아이디 */
     userFileStoreId: string;
 

--- a/src/feed/command/create-feed/create-feed.handler.ts
+++ b/src/feed/command/create-feed/create-feed.handler.ts
@@ -32,7 +32,7 @@ export class CreateFeedHandler implements ICommandHandler<CreateFeedCommand, Cre
         shareAlbumId,
         userId,
         description,
-        contentList: {
+        contentList: contents && {
           createMany: {
             data: contents.map((content) => ({
               userFileStoreId: content.userFileStoreId,

--- a/src/feed/dto/create-feed.dto.ts
+++ b/src/feed/dto/create-feed.dto.ts
@@ -40,9 +40,10 @@ export class CreateFeedRequest {
 
   @ApiProperty({ description: '피드 콘텐츠', type: [CreateFeedItem] })
   @IsArray()
+  @IsOptional()
   @ArrayMinSize(1)
   @Type(() => CreateFeedItem)
-  contents: CreateFeedItem[];
+  contents?: CreateFeedItem[];
 }
 
 @Exclude()


### PR DESCRIPTION
피드 생성 시 콘텐츠 없이 임시 피드를 생성할 수 있어야 합니다.
이미지 업로드 도중 유저가 취소할 수 있기 때문입니다.
이를 처리하기 쉽게 하기 위해 필요합니다.


resolved #34 
closed #34 